### PR TITLE
Updating Script to install v0.9.5

### DIFF
--- a/bin/baasbox_setup.sh
+++ b/bin/baasbox_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Baasbox 0.9.4
-URL="http://www.baasbox.com/?wpdmact=process&did=NTIuaG90bGluaw=="
+# Baasbox 0.9.5
+URL="http://www.baasbox.com/?wpdmact=process&did=NTUuaG90bGluaw=="
 
 cd $OPENSHIFT_DATA_DIR
 


### PR DESCRIPTION
I just updated the URL to fetch `v0.9.5` latest stable version from BaasBox instead of `v.0.9.4`
